### PR TITLE
Update to Jupyter image to fix image permissions & support explicit git version extract in charts

### DIFF
--- a/.github/workflows/merge-docker.yml
+++ b/.github/workflows/merge-docker.yml
@@ -40,9 +40,12 @@ jobs:
       # egeria-configure needs to install utilities
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+      # This action will also use the file .tag-append which might contain an
+      # additional value like '-0' to represent an extension to the version,ie
+      # for rebuilds. This should be reset for each revision
       - name: Set Release version env variable - base it on the last part of what we have in the dockerfile FROM line
         run: |
-          echo "VERSION=$(cat Dockerfile | grep FROM | awk -F':' '{print $2}')" >> $GITHUB_ENV
+          echo "VERSION=$(cat Dockerfile | grep FROM | awk -F':' '{print $2}')(cat .tag-append|grep -v '#')" >> $GITHUB_ENV
       - name: Build and push(jupyter) to quay.io and docker.io
         uses: docker/build-push-action@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea
+# Used to save status when running containers
+.setupComplete
+# Jupyter notebook temp/update files
+**/.ipynb_checkpoints

--- a/.tag-append
+++ b/.tag-append
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project.
+#
+# Any uncommmented string below is appended to the container tag name
+# This is used to support rebuilds/fixes to our image where the base
+# notebook image remains the same
+-1
+# Do not add any newlines

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@
 # This build script corrects some permission issues needed to run
 # on some enterprise k8s environments. see https://github.com/odpi/egeria-jupyter-notebooks/issues/9
 
-# TODO: Move to later version
+# The published image tag is taken from the numerical version of
+# our base image, and appended with the contents of .tag-append (file)
 FROM docker.io/jupyter/minimal-notebook:lab-3.5.0
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,12 @@ FROM docker.io/jupyter/minimal-notebook:lab-3.5.0
 
 USER root
 
+# Needed to dynamically add the selected user on startup - see link below
+RUN chmod g+w /etc/passwd
+
 RUN chown -R $NB_UID:$NB_GID $HOME
 
 # https://cloud.redhat.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
-RUN chgrp -Rf root /home/$NB_USER && chmod -Rf g+w /home/$NB_USER
+RUN chgrp -Rf root /home/$NB_USER && chmod -Rf g+w /home/$NB_USER && chgrp -Rf root /opt/conda && chmod -Rf g+w /opt/conda
 
 USER 1000


### PR DESCRIPTION
See odpi/egeria#178


* Ensures that /opt/conda has appropriate permissions for additional components to be installed (this was failing silently)
* Ensure the dynamic user used in openshift (or other enterprise k8s environments with tight security) is added to the passwd file to ensure applications run normally
* Added support to append a value to the image tag for the container image. By default this picks up the version of the base image we use. However if that hasn't changed, but we need to make a fix, we need a new, unique value. Therefore you can now add a value into .tag-append which will extend this value, ie instead of 'lab-3.5.0' we might have 'lab-3.5.0-1'. Ideally this will be cleared the next time the base image is updated