### PR TITLE
#7258 update jupyter lab to 3.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 # The published image tag is taken from the numerical version of
 # our base image, and appended with the contents of .tag-append (file)
-FROM docker.io/jupyter/minimal-notebook:lab-3.5.0
+FROM docker.io/jupyter/minimal-notebook:lab-3.5.3
 
 USER root
 


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Updates jupyter image to 3.5.3