### PR TITLE
Revert jupyter version

### DIFF
--- a/.tag-append
+++ b/.tag-append
@@ -4,5 +4,5 @@
 # Any uncommmented string below is appended to the container tag name
 # This is used to support rebuilds/fixes to our image where the base
 # notebook image remains the same
--1
+#-1
 # Do not add any newlines

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 # The published image tag is taken from the numerical version of
 # our base image, and appended with the contents of .tag-append (file)
-FROM docker.io/jupyter/minimal-notebook:lab-3.5.3
+FROM docker.io/jupyter/minimal-notebook:lab-3.5.2
 
 USER root
 


### PR DESCRIPTION
revert jupyter version due to 
```
[W 2023-01-31 17:11:27.514 ServerApp] notebook_shim | error linking extension: invalid literal for int() with base 10: 'tcp://172.21.171.70:8888'
    Traceback (most recent call last):
      File "/opt/conda/lib/python3.10/site-packages/traitlets/traitlets.py", line 656, in get
        value = obj._trait_values[self.name]
    KeyError: 'port'
```
in the coco environment