### PR TITLE
Improve instructions and remove ID refresh

### DIFF
--- a/asset-management-labs/automated-curation.ipynb
+++ b/asset-management-labs/automated-curation.ipynb
@@ -621,30 +621,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
-    "\n",
-    "This next command requests the integration daemon refreshes its config immediately rather than waiting for the next refresh cycle.\n",
-    "\n",
-    "---"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "refreshIntegrationGroupConfig(exchangeDL01Name, exchangeDL01PlatformName, exchangeDL01PlatformURL, petersUserId, integrationGroupName)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "----\n",
     "\n",
-    "When Peter checks the configuration of the integration daemon, he sees that the connector for Oak Dene hospital is running.\n",
+    "When Peter checks the configuration of the integration daemon, he sees that the connector for Oak Dene hospital is running.  (If it is not yet running, retry the call to getIntegrationDaemonStatus)\n",
     "\n",
     "----"
    ]
@@ -1353,7 +1332,9 @@
    "source": [
     "----\n",
     "\n",
-    "The file is created in the data lake folder with all of the correct attributes.  *(If no assets are returned, repeatedly run the cell again until an asset appears.)*\n",
+    "The file is created in the data lake folder with all of the correct attributes.  \n",
+    "\n",
+    "*If no asset is returned, or a classification is missing, repeatedly run* assetOwnerPrintAssets *again until the fully populated asset appears.*\n",
     "\n",
     "----"
    ]
@@ -1738,7 +1719,9 @@
    "source": [
     "----\n",
     "\n",
-    "Peter checks that all of the files have been created and catalogued in the data lake folder ...\n",
+    "Peter checks that all of the files have been created and catalogued in the data lake folder ... \n",
+    "\n",
+    "There should be 8 assets returned, each with an owner, origin an zones classification set up. If the list is incomplete, or, for example, the origin classification is missing from some of the assets, then try the query again as one or more of the governance actions listed above are still running.\n",
     "\n",
     "----"
    ]
@@ -1882,22 +1865,23 @@
    "source": [
     "asset = getArchivedFileByPathName(cocoMDS1Name, cocoMDS1PlatformName, cocoMDS1PlatformURL, \"asset-owner\", petersUserId, oakDeneLandingAreaFullPath + \"/week3.csv\")\n",
     "\n",
-    "print(\"Element: \" + asset.get('elementGUID'))\n",
-    "elementProperties = asset.get('elementProperties')\n",
-    "if elementProperties:\n",
-    "    print(\"Properties:\")\n",
-    "    properties = elementProperties.get('propertyValueMap')\n",
-    "    propertyList = list(properties)\n",
-    "    for x in range(len(propertyList)):\n",
-    "        propertyStructure = properties.get(propertyList[x])\n",
-    "        propertyValue = propertyStructure.get('primitiveValue')\n",
-    "        print(\"    \" + propertyList[x] + \": \" + propertyValue)\n",
+    "if asset:\n",
+    "    print(\"Element: \" + asset.get('elementGUID'))\n",
+    "    elementProperties = asset.get('elementProperties')\n",
+    "    if elementProperties:\n",
+    "        print(\"Properties:\")\n",
+    "        properties = elementProperties.get('propertyValueMap')\n",
+    "        propertyList = list(properties)\n",
+    "        for x in range(len(propertyList)):\n",
+    "            propertyStructure = properties.get(propertyList[x])\n",
+    "            propertyValue = propertyStructure.get('primitiveValue')\n",
+    "            print(\"    \" + propertyList[x] + \": \" + propertyValue)\n",
     "\n",
-    "classifications = asset.get('classifications')\n",
-    "if classifications:\n",
-    "    print(\"Classifications:\")\n",
-    "    for x in range(len(classifications)):\n",
-    "        print(\"    \" + classifications[x].get('classificationName'))\n",
+    "    classifications = asset.get('classifications')\n",
+    "    if classifications:\n",
+    "        print(\"Classifications:\")\n",
+    "        for x in range(len(classifications)):\n",
+    "            print(\"    \" + classifications[x].get('classificationName'))\n",
     "\n",
     "\n"
    ]


### PR DESCRIPTION
This PR updates the automated curation lab to improve the instructions to retry a query for an asset or assets, if either there are assets missing fron the list, or there are classifications missing from the assets.

I have also removed the call to refresh the integration daemon once the integration group is created.  This is not necessary. 