### PR TITLE
Add testEntityTypes option

### DIFF
--- a/conformance-testing-labs/run-conformance-test-suite.ipynb
+++ b/conformance-testing-labs/run-conformance-test-suite.ipynb
@@ -81,7 +81,7 @@
     "ctsPlatformURL = os.environ.get('ctsPlatformURL','https://localhost:9445')\n",
     "\n",
     "def checkServerPlatform(testPlatformName, testPlatformURL):\n",
-    "    response = requests.get(testPlatformURL + \"/open-metadata/platform-services/users/garygeeke/server-platform/origin/\", verify=False)\n",
+    "    response = requests.get(testPlatformURL + \"/open-metadata/platform-services/users/garygeeke/server-platform/origin\", verify=False)\n",
     "    if response.status_code == 200:\n",
     "        print(\"   ...\", testPlatformName, \"at\", testPlatformURL, \"is active - ready to begin\")\n",
     "    else:\n",
@@ -166,8 +166,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll also need a JSON request body for configuration of the workbench. \n",
-    "This can be used to set the pageSize used in searches."
+    "We'll also need a JSON request body for configuration of the repository workbench.\n",
+    "\n",
+    "* tutRepositoryServerName - name of the server to test.\n",
+    "* maxSearchResults - set the pageSize used in searches.\n",
+    "* testEntityTypes - optional list of entity types that isu sed to restrict the langth of the test.\n"
    ]
   },
   {
@@ -178,8 +181,9 @@
    "source": [
     "workbenchConfigBody = {\n",
     "    \"class\"                  : \"RepositoryConformanceWorkbenchConfig\",\n",
-    "    \"tutRepositoryServerName\": sutServerName ,\n",
-    "    \"maxSearchResults\"       : 10\n",
+    "    \"tutRepositoryServerName\": sutServerName,\n",
+    "    \"maxSearchResults\"       : 10,\n",
+    "    \"testEntityTypes\"        : [\"Asset\"]\n",
     "}"
    ]
   },
@@ -732,7 +736,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -746,7 +750,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This adds an option to the configuration of the repository workbench to restrict the test to:

* The Asset entity type and its super types (Referenceable and OpenMetadataRoot)
* All relationships between the Asset entity and its super types
* All classifications that can be attached to Asset or it super types.

The test runs in under half an hour with this change.

There is a small change to the URL that is used to test if the platform is running.  Now it correctly detects that the platform is ok.
